### PR TITLE
Optionally allow seeing private posts by group and trust level

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/topic-above-posts/privatereplies.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-posts/privatereplies.hbs
@@ -4,7 +4,19 @@
     {{d-icon 'user-secret'}}
     <div>
       <p>{{i18n 'private_replies.topic_banner_line_1'}}</p>
-      <p>{{i18n 'private_replies.topic_banner_line_2'}}</p>
+      {{#if (eq siteSettings.private_replies_min_trust_level_to_see_all -1)}}
+        {{#if (eq siteSettings.private_replies_topic_starter_primary_group_can_see_all true)}}
+          <p>{{i18n 'private_replies.topic_banner_line_2_also_group'}}</p>
+        {{else}}
+          <p>{{i18n 'private_replies.topic_banner_line_2'}}</p>
+        {{/if}}
+      {{else}}
+        {{#if (eq siteSettings.private_replies_topic_starter_primary_group_can_see_all true)}}
+          <p>{{i18n 'private_replies.topic_banner_line_2_also_trusted_group'}}</p>
+        {{else}}
+          <p>{{i18n 'private_replies.topic_banner_line_2_also_trusted'}}</p>
+        {{/if}}
+      {{/if}}
     </div>
   </div>
 </div>

--- a/assets/javascripts/discourse/templates/connectors/topic-above-posts/privatereplies.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-posts/privatereplies.hbs
@@ -4,18 +4,10 @@
     {{d-icon 'user-secret'}}
     <div>
       <p>{{i18n 'private_replies.topic_banner_line_1'}}</p>
-      {{#if (eq siteSettings.private_replies_min_trust_level_to_see_all -1)}}
-        {{#if (eq siteSettings.private_replies_topic_starter_primary_group_can_see_all true)}}
-          <p>{{i18n 'private_replies.topic_banner_line_2_also_group'}}</p>
-        {{else}}
-          <p>{{i18n 'private_replies.topic_banner_line_2'}}</p>
-        {{/if}}
+      {{#if (eq siteSettings.private_replies_topic_starter_primary_group_can_see_all true)}}
+        <p>{{i18n 'private_replies.topic_banner_line_2_also_group'}}</p>
       {{else}}
-        {{#if (eq siteSettings.private_replies_topic_starter_primary_group_can_see_all true)}}
-          <p>{{i18n 'private_replies.topic_banner_line_2_also_trusted_group'}}</p>
-        {{else}}
-          <p>{{i18n 'private_replies.topic_banner_line_2_also_trusted'}}</p>
-        {{/if}}
+        <p>{{i18n 'private_replies.topic_banner_line_2'}}</p>
       {{/if}}
     </div>
   </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3,6 +3,9 @@ en:
     private_replies:
       topic_banner_line_1: "You can only see posts made by the topic owner, staff and yourself."
       topic_banner_line_2: "Only the topic owner can see all posts."
+      topic_banner_line_2_also_trusted: "Only the topic owner and trusted users can see all posts."
+      topic_banner_line_2_also_group: "Only the topic owner and their primary group can see all posts."
+      topic_banner_line_2_also_trusted_group: "Only the topic owner, their primary group and trusted users can see all posts."
       button:
         public_replies: 
           button: "Public Replies"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2,10 +2,8 @@ en:
   js:
     private_replies:
       topic_banner_line_1: "You can only see posts made by the topic owner, staff and yourself."
-      topic_banner_line_2: "Only the topic owner can see all posts."
-      topic_banner_line_2_also_trusted: "Only the topic owner and trusted users can see all posts."
-      topic_banner_line_2_also_group: "Only the topic owner and their primary group can see all posts."
-      topic_banner_line_2_also_trusted_group: "Only the topic owner, their primary group and trusted users can see all posts."
+      topic_banner_line_2: "Only the topic owner and trusted users can see all posts."
+      topic_banner_line_2_also_group: "Only the topic owner, their primary group and trusted users can see all posts."
       button:
         public_replies: 
           button: "Public Replies"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,3 +1,5 @@
 en:
   site_settings:
     private_replies_enabled: "Enable the Private Replies plugin."
+    private_replies_min_trust_level_to_see_all: "Minimum trust level required to see all private posts (-1 to disable)."
+    private_replies_topic_starter_primary_group_can_see_all: "Whether the topic starter's primary group members can see all private posts"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,5 +1,5 @@
 en:
   site_settings:
     private_replies_enabled: "Enable the Private Replies plugin."
-    private_replies_min_trust_level_to_see_all: "Minimum trust level required to see all private posts (-1 to disable)."
+    private_replies_min_trust_level_to_see_all: "Minimum trust level required to see all private posts."
     private_replies_topic_starter_primary_group_can_see_all: "Whether the topic starter's primary group members can see all private posts"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,9 +4,8 @@ plugins:
     default: false
   private_replies_min_trust_level_to_see_all:
     client: true
-    default: -1
-    min: -1
-    max: 4
+    default: 4
+    enum: "TrustLevelSetting"
   private_replies_topic_starter_primary_group_can_see_all:
     client: true
     default: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,8 +3,10 @@ plugins:
     client: true
     default: false
   private_replies_min_trust_level_to_see_all:
+    client: true
     default: -1
     min: -1
     max: 4
   private_replies_topic_starter_primary_group_can_see_all:
+    client: true
     default: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,4 +2,9 @@ plugins:
   private_replies_enabled:
     client: true
     default: false
-
+  private_replies_min_trust_level_to_see_all:
+    default: -1
+    min: -1
+    max: 4
+  private_replies_topic_starter_primary_group_can_see_all:
+    default: false


### PR DESCRIPTION
This PR adds two features.

First, it adds a setting to let the users in the topic creator's primary group see private posts within that topic. My company, Haddee, is planning to use this to allow teacher's assistants to see student work.

Second, it adds a setting to let users with a given trust level see all private posts in all topics.

I developed and tested this locally on the newest version of Discourse.