### PR TITLE
clarified fr translation for public/private button

### DIFF
--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -4,9 +4,9 @@ fr:
       topic_banner_line_1: "Vous ne pouvez voir que les messages publiés par le propriétaire du sujet, le personnel et vous-même."
       topic_banner_line_2: "Seul le propriétaire du sujet peut voir tous les messages."
       button:
-        public_replies: 
-          button: "Réponses publiques"
+        public_replies:
+          button: "Répondre en public"
           help: "Définir toutes les réponses de ce sujet visibles par tous"
-        private_replies: 
-          button: "Réponses privées"
+        private_replies:
+          button: "Répondre en privé"
           help: "Rendre les réponses à ce sujet visibles uniquement par le propriétaire du sujet"


### PR DESCRIPTION
The buttons are currently so confusing that we need to write a note to all our French users to inform that the button does the opposite of what it says.
Users think that when it says `"réponses privées" the answers are private (as written).

The button is meant to say the action when clicking, not the current status. Therefore it should be an action verb ("répondre") like for the other buttons next to it.
